### PR TITLE
DSO missing from command line FIXED

### DIFF
--- a/net_plumber/Ubuntu-NetPlumber-Release/makefile
+++ b/net_plumber/Ubuntu-NetPlumber-Release/makefile
@@ -47,7 +47,7 @@ all: net_plumber
 net_plumber: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	g++  -o "net_plumber" $(OBJS) $(USER_OBJS) $(LIBS)
+	g++  -o "net_plumber" $(OBJS) $(USER_OBJS) $(LIBS) -lpthread
 	@echo 'Finished building target: $@'
 	@echo ' '
 


### PR DESCRIPTION
If you try to compile it you will get the following error:
```
Building target: net_plumber
Invoking: GCC C++ Linker
g++  -o "net_plumber"  ./src/net_plumber/test/conditions_unit.o ./src/net_plumber/test/net_plumber_basic_unit.o ./src/net_plumber/test/net_plumber_plumbing_unit.o  ./src/net_plumber/conditions.o ./src/net_plumber/main.o ./src/net_plumber/main_processes.o ./src/net_plumber/net_plumber.o ./src/net_plumber/net_plumber_utils.o ./src/net_plumber/node.o ./src/net_plumber/rpc_handler.o ./src/net_plumber/rule_node.o ./src/net_plumber/source_node.o ./src/net_plumber/source_probe_node.o  ./src/jsoncpp/jsoncpp.o ./src/jsoncpp/jsonrpc_client.o ./src/jsoncpp/jsonrpc_handler.o ./src/jsoncpp/jsonrpc_server.o ./src/jsoncpp/jsonrpc_tcpclient.o ./src/jsoncpp/jsonrpc_tcpserver.o ./src/jsoncpp/jsonrpc_udpclient.o ./src/jsoncpp/jsonrpc_udpserver.o ./src/jsoncpp/netstring.o ./src/jsoncpp/networking.o ./src/jsoncpp/system.o  ./src/headerspace/array.o ./src/headerspace/hs.o   -llog4cxx -lcppunit
/usr/bin/ld: ./src/jsoncpp/system.o: undefined reference to symbol 'pthread_mutexattr_init@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:48: recipe for target 'net_plumber' failed
make: *** [net_plumber] Error 1
```
With -lpthread FLAG it's solved 